### PR TITLE
added justify-content: center; 

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -191,6 +191,7 @@ button:hover {
 /* This is for the crypto-currency page so all the cards wrap */
 #cardsContainer .cardsWrapper {
   display: flex;
+  justify-content: center;
   flex-wrap: wrap;
   flex-direction: row;
   width: auto;


### PR DESCRIPTION
to .cardsWrapper on the crypto-currency page to center all of the coin cards because they would become really miss aligned on different screen sizes